### PR TITLE
Add method to reset filters

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,14 @@ dynamic_filters = DynamicFilters(df, ['Category', 'Item'])
 ### `check_state(self)`
 Initializes the session state with filters if not already set.
 
+### `reset_filters(self)`
+Resets the current filter.
+
+#### Example:
+```python
+st.button("Reset Filters", on_click=dynamic_filters.reset_filters)
+```
+
 ### `filter_df(self, except_filter=None)`
 Filters the dataframe based on session state values except for the specified filter.
 

--- a/streamlit-dynamic-filters/dynamic_filters.py
+++ b/streamlit-dynamic-filters/dynamic_filters.py
@@ -50,6 +50,18 @@ class DynamicFilters:
         #     st.session_state.filters = self.filters
         if self.filters_name not in st.session_state:
             st.session_state[self.filters_name] = self.filters
+            
+    def reset_filters(self):
+        """
+        Resets the current filter.
+
+        Can be called using a button:
+        
+            st.button("Reset Filters", on_click=dynamic_filters.reset_filters)
+            
+        """
+        if self.filters_name in st.session_state:
+            del st.session_state[self.filters_name]
 
     def filter_df(self, except_filter=None):
         """


### PR DESCRIPTION
I missed a function to reset all filters using a single button, so I added a method for it. :)
Can be called from a button:

#### Example:
```python
st.button("Reset Filters", on_click=dynamic_filters.reset_filters)
```